### PR TITLE
fixes extbase/fluid OOM Errors

### DIFF
--- a/Classes/Handler.php
+++ b/Classes/Handler.php
@@ -165,6 +165,8 @@ class Handler {
 	 */
 	protected function mergeTypoScript(array $linkConfigurationArray , array $typoLinkConfigurationArray, $recordTableName) {
 
+		unset($typoLinkConfigurationArray['parameter']);
+
 			// precompile the "additionalParams"
 		$linkConfigurationArray[$recordTableName . '.']['additionalParams'] = $this->localContentObject->stdWrap($linkConfigurationArray[$recordTableName . '.']['additionalParams'], $linkConfigurationArray[$recordTableName . '.']['additionalParams.']);
 		unset($linkConfigurationArray[$recordTableName . '.']['additionalParams.']);


### PR DESCRIPTION
fixes OOM Errors with fluid/extbase (on 6.2b5) where any attempt to create typolink handled by linkhandler will fail with fatal OOM error. 

Solution taken from: 
http://forge.typo3.org/issues/38700 
http://forge.typo3.org/attachments/21507/fluid_loop.patch
