### PR TITLE
[BUGFIX] Reverse merging order for TypoScript configuration

### DIFF
--- a/Classes/Handler.php
+++ b/Classes/Handler.php
@@ -186,7 +186,7 @@ class Handler {
 			if (array_key_exists('parameter.', $typoLinkConfigurationArray)) {
 				unset($typoLinkConfigurationArray['parameter.']);
 			}
-			$linkConfigurationArray[$recordTableName . '.'] = array_merge($linkConfigurationArray[$recordTableName . '.'], $typoLinkConfigurationArray);
+			$linkConfigurationArray[$recordTableName . '.'] = array_merge($typoLinkConfigurationArray, $linkConfigurationArray[$recordTableName . '.']);
 		}
 
 		return $linkConfigurationArray[$recordTableName . '.'];


### PR DESCRIPTION
You have an error in your merging order. The configuration from
TypoScript has to overrule the one from ContentObjectRenderer as
otherwise your parameter loops to its own.
