### PR TITLE
Add intval to the sys_language_uid value in TceMain.php

### DIFF
--- a/Classes/Hooks/TceMain.php
+++ b/Classes/Hooks/TceMain.php
@@ -108,7 +108,7 @@ class TceMain {
 
 				$queryString = '&eID=linkhandlerPreview&linkParams=' . $linkParamValue . $wsPreviewValue;
 				$languageParam = '&L=' . $recordArray['sys_language_uid'];
-				$queryString  .= $languageParam . '&authCode=' . \TYPO3\CMS\Core\Utility\GeneralUtility::stdAuthCode($linkParamValue . $wsPreviewValue . $recordArray['sys_language_uid'], '', 32);
+				$queryString  .= $languageParam . '&authCode=' . \TYPO3\CMS\Core\Utility\GeneralUtility::stdAuthCode($linkParamValue . $wsPreviewValue . intval($recordArray['sys_language_uid']), '', 32);
 
 				$GLOBALS['_POST']['viewUrl'] = $previewDomain . '/index.php?id=' . $previewPageId . $queryString . '&y=';
 				$GLOBALS['_POST']['popViewId_addParams'] = $queryString;


### PR DESCRIPTION
The save-and-show button was failing the validation in Eid.php:validateAuthCode
By adding intval to $recordArray['sys_language_uid'] the NULL value becomes a 0 thus passing the validation.
