### PR TITLE
[BUGFIX] Removing (seemingly?) unused property reference

### DIFF
--- a/Classes/RecordTab.php
+++ b/Classes/RecordTab.php
@@ -208,7 +208,6 @@ class RecordTab implements \AOE\Linkhandler\TabHandlerInterface {
 			$dblist = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('AOE\Linkhandler\Record\ElementBrowserRecordList');
 			$dblist->setAddPassOnParameters($this->addPassOnParams);
 			$dblist->browselistObj = $this->browseLinksObj;
-			$dblist->this->pObjScript = $this->browseLinksObj->this->pObjScript;
 			$dblist->backPath = $GLOBALS['BACK_PATH'];
 			$dblist->thumbs = 0;
 			$dblist->calcPerms = $GLOBALS['BE_USER']->calcPerms($pageinfo);


### PR DESCRIPTION
Fixes a PHP Warning:
PHP Warning: Creating default object from empty value in ext/linkhandler/Classes/RecordTab.php line 211
