### PR TITLE
[BUGFIX] Receive language parameter in preview script

### DIFF
--- a/Classes/Service/Eid.php
+++ b/Classes/Service/Eid.php
@@ -94,6 +94,7 @@ class Eid {
 	public function initialize() {
 		$authCode = (string) GeneralUtility::_GP('authCode');
 		$linkParams = GeneralUtility::_GP('linkParams');
+		$this->languageId = (int)GeneralUtility::_GP('L');
 
 		$this->validateAuthCode($authCode, $linkParams);
 


### PR DESCRIPTION
Hi devs

this bugfix makes sure the L parameter is properly received in the Eid preview script when "Save & View" is clicked. Prior to this patch, save and view on a overlay record did not work as the $expectedAuthCode was incorrect for the eID script because the languageId was always 0. 
