### PR TITLE
[BUGFIX] Encode link parameters for preview script to make sure semi-col...

### DIFF
--- a/Classes/Hooks/TceMain.php
+++ b/Classes/Hooks/TceMain.php
@@ -106,7 +106,7 @@ class TceMain {
 
 				$linkParamValue = 'record:' . $table . ':' . $id;
 
-				$queryString = '&eID=linkhandlerPreview&linkParams=' . $linkParamValue . $wsPreviewValue;
+				$queryString = '&eID=linkhandlerPreview&linkParams=' . urlencode ($linkParamValue . $wsPreviewValue);
 				$languageParam = '&L=' . $recordArray['sys_language_uid'];
 				$queryString  .= $languageParam . '&authCode=' . \TYPO3\CMS\Core\Utility\GeneralUtility::stdAuthCode($linkParamValue . $wsPreviewValue . intval($recordArray['sys_language_uid']), '', 32);
 


### PR DESCRIPTION
...on gets passed. This allows "Save and View" to work when inside workspaces.
